### PR TITLE
fix(*) don't crash on throughput when duration is null

### DIFF
--- a/about_time/about_time.py
+++ b/about_time/about_time.py
@@ -144,6 +144,9 @@ class HandleStats(Handle):
 
     @property
     def throughput(self):
+        if not self.duration:
+             # In case it was too fast to be measured
+            return float('NaN')
         return self.count / self.duration
 
     @property

--- a/tests/test_about_time.py
+++ b/tests/test_about_time.py
@@ -142,6 +142,7 @@ def test_duration_human(duration, expected):
 
 
 @pytest.mark.parametrize('end, count, expected', [
+    (0, 0, 'nan/s'),
     (1., 1, '1.0/s'),
     (1., 10, '10.0/s'),
     (1., 2500, '2500.0/s'),


### PR DESCRIPTION
I experienced this issue while running [clearly](https://github.com/rsalmei/clearly) tests
```
    def test_server_filter_workers_empty(mocked_server):
        mocked_server.listener.memory.workers.values.return_value = ()

        gen = mocked_server.filter_workers(clearly_pb2.FilterWorkersRequest(), N
one)
        with pytest.raises(StopIteration):
>           next(gen)

test_server.py:129:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\venv\lib\site-packages\clearly\server.py:153: in filter_workers
    for worker in about_time(callback, found_workers):
..\..\venv\lib\site-packages\about_time\about_time.py:91: in counter
    fn(HandleStats(timings, i + 1))
..\..\venv\lib\site-packages\clearly\server.py:151: in callback
    t.count, t.duration_human, t.throughput_human)
..\..\venv\lib\site-packages\about_time\about_time.py:151: in throughput_human
    value = self.throughput
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <about_time.about_time.HandleStats object at 0x03FAD530>

    @property
    def throughput(self):
>       return self.count / self.duration
E       ZeroDivisionError: float division by zero

..\..\venv\lib\site-packages\about_time\about_time.py:147: ZeroDivisionError
===================== 2 failed, 15 passed in 0.25 seconds =====================
```

With the mocks it was so fast that duration was actually zero. And probably because I'm currently on a Python2.7 + Windows system where the `time()` precision is crappy.

So I propose returning NaN in this case