### PR TITLE
typing for `about_time.about_time`

### DIFF
--- a/about_time/core.py
+++ b/about_time/core.py
@@ -1,12 +1,25 @@
+from __future__ import annotations
+
 import time
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
+from typing import Callable, Generic, Iterable, TypeVar, overload
 
 from .human_count import HumanCount
 from .human_duration import HumanDuration
 from .human_throughput import HumanThroughput
 
+T = TypeVar("T")
 
-def about_time(func_or_it=None, *args, **kwargs):
+
+@overload
+def about_time(func: Callable[..., T], *args, **kwargs) -> "HandleResult[T]": ...
+@overload
+def about_time(it: Iterable[T]) -> "HandleStats": ...
+@overload
+def about_time() -> "AbstractContextManager[Handle]": ...
+
+
+def about_time(func_or_it: Callable[..., T] | Iterable[T] | None = None, *args, **kwargs):
     """Measure timing and throughput of code blocks, with beautiful
     human friendly representations.
 
@@ -91,8 +104,8 @@ class Handle(object):
         return HumanDuration(self.duration)
 
 
-class HandleResult(Handle):
-    def __init__(self, timings, result):
+class HandleResult(Generic[T], Handle):
+    def __init__(self, timings, result: T):
         super(HandleResult, self).__init__(timings)
         self.__result = result
 


### PR DESCRIPTION
From https://github.com/rsalmei/about-time/issues/16

What it does:

- allows `HandleResult.result` to have the return type of the function passed into `about_time`
- different type hints based on the usage of `about_time` (eg. static linters will complain when accessing the .throughput property if `about_time` does not wrap an iterable)

Few changes made from comment:

- removed `ParamSpec` since it is not included in `typing` for python 3.8
- import `Callable` and `Iterable` from `typing` because it is an unsubscritable `ABCMeta` in python 3.8
- added `__future__.annotations` for python <3.10 (see [PEP 563](https://peps.python.org/pep-0563/))

I don't think further typing is required for users to have correct autocompletion and type hints.